### PR TITLE
aws & zsh 의 없는 명령어 shellenv 제거 & Owly 설치 불가 에러로 제거

### DIFF
--- a/BrewFile.be
+++ b/BrewFile.be
@@ -5,4 +5,3 @@ cask "ngrok"
 cask "docker"
 cask "gitkraken"
 cask "intellij-idea"
-mas "Owly", id: 882812218

--- a/install.sh
+++ b/install.sh
@@ -18,12 +18,10 @@ elif [ "$type" = "2" ]; then
 fi
 
 # configure aws-cli
-eval "$(/opt/homebrew/bin/aws shellenv)"
 aws configure
 
 # configure zsh
 chmod 755 ./zsh/install.sh
-eval "$(/opt/homebrew/bin/zsh shellenv)"
 ./zsh/install.sh
 chsh -s /bin/zsh
 


### PR DESCRIPTION
shellenv 라는 명령어를 brew 로 설치한 패키지들 (aws 및 zsh) 의 명령어 PATH에 추가하기 위해 사용하고 있는 것으로 보이는데, 이를 위한 shellenv 라는 명령어는 brew 명령어의 고유 명령어로 aws 및 zsh 와는 관련이 없어 에러가 발생하기에 이를 제거하였습니다. 그리고 별도의 PATH 추가 작업을 하지 않아도 aws 및 zsh 의 명령어는 homebrew 의 실행 PATH인 bin/ 에 위치하여 있고 해당 PATH 는 전 단계에서 이미 추가가 될 것이기에 별도로 필요 없을 걸로 판단됩니다.

그 외, 백엔드 패키지의 하나인 Owly 의 경우, AppStore의 에러와 함께 설치를 할 수 없었으며 이는 AppStore 의 구매 내역과도 관련이 있지 않을까 조심스럽게 추측해 봅니다. 이는 개개인의 계정에 따라 실행 결과 성공 여부가 달라질 것으로 보여 제거하였습니다.